### PR TITLE
Remove unused Slack toolError helper

### DIFF
--- a/servers/slack-mcp/src/server.ts
+++ b/servers/slack-mcp/src/server.ts
@@ -414,15 +414,3 @@ function toolText(text: string): CallToolResult {
     ]
   };
 }
-
-function toolError(text: string): CallToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text
-      }
-    ],
-    isError: true
-  };
-}


### PR DESCRIPTION
## Summary

## Summary
- delete the unused `toolError` helper from the Slack MCP server
- rely on the existing `toolText` helper after lint caught the dead code

## Testing
- npm run build