### PR TITLE
Add changelog scaffolding

### DIFF
--- a/servers/gh-mcp/CHANGELOG.md
+++ b/servers/gh-mcp/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to `@servers/gh-mcp` will be documented in this file.
+
+## [Unreleased]
+
+## [0.1.0] - 2025-10-23
+### Added
+- Initial release of the GitHub MCP server with repository, branch, and pull request tooling.

--- a/servers/gh-mcp/README.md
+++ b/servers/gh-mcp/README.md
@@ -68,6 +68,10 @@ TypeScript implementation of a Model Context Protocol (MCP) server that exposes 
 
 - `github://rate-limit` – Returns the remaining rate limit for the authenticated token.
 
+## Changelog
+
+All user-visible changes are tracked in [`CHANGELOG.md`](./CHANGELOG.md). Whenever you modify this server, add a concise entry so the agent can keep release notes in sync.
+
 ## Linting
 
 Run ESLint over the TypeScript sources:

--- a/servers/slack-mcp/CHANGELOG.md
+++ b/servers/slack-mcp/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `@servers/slack-mcp` will be documented in this file.
+
+## [Unreleased]
+### Added
+- Rich Block Kit layout support for `post-message`, including headlines, highlights, fields, CTA buttons, and optional footer context.
+- Optional per-message `username` and `iconEmoji` overrides for Slack posts.
+### Changed
+- `post-pr` now threads the Slack sender overrides so pull request announcements align with other messages.
+- Slack webhook client trims override values before sending payloads.
+### Removed
+- Unused `toolError` helper that was superseded by richer success handling.
+
+## [0.1.0] - 2025-10-23
+### Added
+- Initial release of the Slack MCP server with webhook messaging tooling.

--- a/servers/slack-mcp/README.md
+++ b/servers/slack-mcp/README.md
@@ -64,6 +64,10 @@ Both tools accept optional `username` and `iconEmoji` arguments to override the 
 - `attachments` – Optional raw Slack attachments array passed through.
 - `username` / `iconEmoji` – Override sender metadata per message.
 
+## Changelog
+
+All user-visible changes are tracked in [`CHANGELOG.md`](./CHANGELOG.md). When you adjust tooling or behaviors, append a summary to keep the changelog aligned with the code.
+
 ## Environment Variables
 
 - `SLACK_WEBHOOK_URL` – Default webhook URL for Slack.


### PR DESCRIPTION
## Summary

## Summary
- create `CHANGELOG.md` files for both gh-mcp and slack-mcp servers
- document in each README that contributors must keep the changelog entries up to date

## Testing
- not run